### PR TITLE
Fix Pages build by removing submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ homebrew-tap/
 gopassgen-*.tar.gz
 gopassgen-*-darwin-arm64
 
-# macOS system file
-.DS_Store
+# macOS system file.DS_Store
+docs/public/


### PR DESCRIPTION
## Summary
- remove obsolete `docs/public` submodule
- ignore the build output directory

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e14131c5083259ce0185b2b19ee81